### PR TITLE
Use Draw Image

### DIFF
--- a/ipyvtk_simple/viewer.py
+++ b/ipyvtk_simple/viewer.py
@@ -132,7 +132,7 @@ class ViewInteractiveWidget(Canvas):
         """Updates the canvas with the current render"""
         raw_img = self.get_image(force_render=force_render)
         f = BytesIO()
-        PIL.Image.fromarray(raw_img).save(f, 'png')
+        PIL.Image.fromarray(raw_img).save(f, 'JPEG')
         image = Image(
             value=f.getvalue(), width=self.width, height=self.height
         )
@@ -256,8 +256,10 @@ class ViewInteractiveWidget(Canvas):
                 self.update_interactor_event_data(event)
                 self.interactor.LeaveEvent()
                 self.last_mouse_move_event = None
-                # if self.dragging:
-                    # self.dragging = False
+                if self.dragging:  # have to trigger a leave event and release event
+                    self.interactor.LeftButtonReleaseEvent()
+                    self.dragging = False
+                self.full_render()
             elif event_name == "mousedown":
                 self.dragging = True
                 self.send_pending_mouse_move_event()

--- a/ipyvtk_simple/viewer.py
+++ b/ipyvtk_simple/viewer.py
@@ -57,7 +57,7 @@ class ViewInteractiveWidget(Canvas):
 
         # record first render time
         tstart = time.time()
-        self.put_image_data(self.get_image(force_render=True))
+        self.update_canvas()
         self._first_render_time = time.time() - tstart
         log.debug('First image in %.5f seconds', self._first_render_time)
 
@@ -124,6 +124,11 @@ class ViewInteractiveWidget(Canvas):
         elif delay_sec > self.quick_render_delay_sec_range[1]:
             delay_sec = self.quick_render_delay_sec_range[1]
         self.quick_render_delay_sec = delay_sec
+
+    def update_canvas():
+        """Updates the canvas with the current render"""
+        self.put_image_data(self.get_image(force_render=True))
+
 
     def get_image(self, force_render=True):
         if force_render:

--- a/ipyvtk_simple/viewer.py
+++ b/ipyvtk_simple/viewer.py
@@ -38,7 +38,7 @@ class ViewInteractiveWidget(Canvas):
     """
 
     def __init__(self, render_window, log_events=True,
-                 transparent_background=False, allow_wheel=True, quality=75,
+                 transparent_background=False, allow_wheel=True, quality=85,
                  **kwargs):
         """Accepts a vtkRenderWindow."""
 

--- a/ipyvtk_simple/viewer.py
+++ b/ipyvtk_simple/viewer.py
@@ -34,11 +34,11 @@ class ViewInteractiveWidget(Canvas):
     ----------
     quality : float
         Compression quality.  100 for best quality, 0 for min quality.
-        Default 75.
+        Default 80.
     """
 
     def __init__(self, render_window, log_events=True,
-                 transparent_background=False, allow_wheel=True, quality=85,
+                 transparent_background=False, allow_wheel=True, quality=80,
                  **kwargs):
         """Accepts a vtkRenderWindow."""
 

--- a/ipyvtk_simple/viewer.py
+++ b/ipyvtk_simple/viewer.py
@@ -28,14 +28,24 @@ log.addHandler(logging.StreamHandler())
 
 
 class ViewInteractiveWidget(Canvas):
-    """Remote controller for VTK render windows."""
+    """Remote controller for VTK render windows.
+
+    Parameters
+    ----------
+    quality : float
+        Compression quality.  100 for best quality, 0 for min quality.
+        Default 75.
+    """
 
     def __init__(self, render_window, log_events=True,
-                 transparent_background=False, allow_wheel=True, **kwargs):
+                 transparent_background=False, allow_wheel=True, quality=75,
+                 **kwargs):
         """Accepts a vtkRenderWindow."""
 
         super().__init__(**kwargs)
-
+        if quality < 0 or quality > 100:
+            raise ValueError('`quality` parameter must be between 0 and 100')
+        self._quality = quality
         self._render_window = weakref.ref(render_window)
         self.render_window.SetOffScreenRendering(1)  # Force off screen
         self.transparent_background = transparent_background
@@ -132,7 +142,7 @@ class ViewInteractiveWidget(Canvas):
         """Updates the canvas with the current render"""
         raw_img = self.get_image(force_render=force_render)
         f = BytesIO()
-        PIL.Image.fromarray(raw_img).save(f, 'JPEG')
+        PIL.Image.fromarray(raw_img).save(f, 'JPEG', quality=self._quality)
         image = Image(
             value=f.getvalue(), width=self.width, height=self.height
         )


### PR DESCRIPTION
Turns out that when remotely rending, you have to use `draw_image` for speed.  This brings performance back up and enables image compression (again) with JPEG.  Quality is now an input parameter.

This also fixes a minor bug where the first grab and drag doesn't register and another bug where dragging and leaving produces undesirable behavior in the plotter.