### PR TITLE
Add imports to __init__

### DIFF
--- a/ipyvtk_simple/__init__.py
+++ b/ipyvtk_simple/__init__.py
@@ -1,0 +1,2 @@
+from ._version import __version__
+from .viewer import ViewInteractiveWidget


### PR DESCRIPTION
Nitpicking here, but it would be nice to have __version__ available at the module level like most python packages, and we should expose `ViewInteractiveWidget` at the module level as well.