### PR TITLE
input extremely and overly sensitive mouse response

### DIFF
--- a/ipyvtk_simple/viewer.py
+++ b/ipyvtk_simple/viewer.py
@@ -250,7 +250,6 @@ class ViewInteractiveWidget(Canvas):
             scale_x = self.width/event['boundingRectWidth']
             event['offsetX'] = round(event['offsetX']*scale_x)
             event['offsetY'] = round(event["clientY"]-event["boundingRectTop"]) #re-calculate coordinates
-            scale_x = self.width/event['boundingRectWidth']
             scale_y = self.height/event['boundingRectHeight']
             event['offsetY'] = round(event['offsetY']*scale_y)
 

--- a/ipyvtk_simple/viewer.py
+++ b/ipyvtk_simple/viewer.py
@@ -243,11 +243,17 @@ class ViewInteractiveWidget(Canvas):
         # we have to scale the mouse movement here relative to the
         # canvas size, otherwise mouse movement won't correspond to
         # the render window.
+
+
         if 'offsetX' in event:
+            event['offsetX'] = round(event["clientX"]-event["boundingRectLeft"]) #re-calculate coordinates
             scale_x = self.width/event['boundingRectWidth']
             event['offsetX'] = round(event['offsetX']*scale_x)
+            event['offsetY'] = round(event["clientY"]-event["boundingRectTop"]) #re-calculate coordinates
+            scale_x = self.width/event['boundingRectWidth']
             scale_y = self.height/event['boundingRectHeight']
             event['offsetY'] = round(event['offsetY']*scale_y)
+
 
         try:
             if self.log_events:


### PR DESCRIPTION
Mouse events on Firefox not always return the offsetX/Y Property, sometimes the response is 0 generating a weird user interaction response. This PR fixes the problem by recalculating the offsetX/Y property by subtracting clientX/Y and boundingRectLeft/Top properties