### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,11 @@ RUN adduser --disabled-password \
     --uid ${NB_UID} \
     ${NB_USER}
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libgl1-mesa-dev xvfb tini && \
+RUN wget -qO - https://deb.nodesource.com/setup_15.x | bash && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends libgl1-mesa-dev xvfb tini nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-RUN conda install --quiet --yes nodejs
 RUN conda install --quiet --yes -c conda-forge \
     ipywidgets \
     ipycanvas>=0.5.0 \


### PR DESCRIPTION
The current Dockerfile produces the following error:
```
An error occured.
ValueError: Please install nodejs >=12.0.0 before continuing. nodejs may be installed using conda or directly from the nodejs website.
```
Can also be reproduced by running the Binder-link:https://mybinder.org/v2/gh/Kitware/ipyvtk-simple/master
This PR fixes this by getting the latest nodejs with wget.